### PR TITLE
Update GCD.lua

### DIFF
--- a/GCD.lua
+++ b/GCD.lua
@@ -299,7 +299,7 @@ function addon:Unlock()
 		end
 	end
 	if unlocked then
-		local cursor = cursorFrame or CreateFrame("Frame")
+		local cursor = cursorFrame or CreateFrame("Frame", nil, UIParent, "BackdropTemplate")
 		cursor:SetWidth(20)
 		cursor:SetHeight(20)
 		cursor:SetBackdrop(cursorBackdrop)


### PR DESCRIPTION
Fix: attempt to call method 'SetBackdrop' (a nil value) error> The backdrop API has been moved to BackdropTemplate. Handling for Unlock functionality